### PR TITLE
Fix Missile.from_db to use correct field names

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -72,7 +72,7 @@ class Missile extends Msg {
     static from_db(db_entry) {
         let destination = new GeoLocation(db_entry.destLat, db_entry.destLong);
         let currentLocation = new GeoLocation(db_entry.currentLat, db_entry.currentLong);
-        return new Missile(db_entry.type, db_entry.status, destination, currentLocation, db_entry.missileId, db_entry.radius, db_entry.sentbyusername, db_entry.timesent, db_entry.etatimetoimpact);
+        return new Missile(db_entry.type, db_entry.status, destination, currentLocation, db_entry.id, db_entry.radius, db_entry.sentBy, db_entry.sentAt, db_entry.timeToImpact);
     }
 }
 exports.Missile = Missile;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,11 +108,11 @@ class Missile extends Msg {
                            db_entry.status,
                            destination,
                            currentLocation,
-                           db_entry.missileId,
+                           db_entry.id,
                            db_entry.radius,
-                           db_entry.sentbyusername,
-                           db_entry.timesent,
-                           db_entry.etatimetoimpact);
+                           db_entry.sentBy,
+                           db_entry.sentAt,
+                           db_entry.timeToImpact);
     }
 
 }


### PR DESCRIPTION
Original version of the function wasn't using the correct fieldnames causing some information to be lost. This fixes this to properly match against the Prisma schema.